### PR TITLE
feat: shorthand url plugin syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "arbitrary"
@@ -2074,9 +2074,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2309,18 +2309,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.91"
+anyhow = "1.0.92"
 chrono = "0.4.38"
 clap = { version = "4.5.20", features = ["derive"] }
 cliclack = "0.3.5"
@@ -12,9 +12,9 @@ confy = "0.6.1"
 extism = "1.8.0"
 home = "0.5.9"
 rand = "0.8.5"
-reqwest = { version = "0.12.8", features = ["blocking"] }
+reqwest = { version = "0.12.9", features = ["blocking"] }
 semver = "1.0.23"
-serde = { version = "1.0.213", features = ["derive"] }
+serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
 sha256 = "1.5.0"
 env_logger = "0.11.5"

--- a/changeset-config.schema.json
+++ b/changeset-config.schema.json
@@ -8,24 +8,16 @@
 	"properties": {
 		"plugin": {
 			"type": "object",
-			"description": "A list of plugins to use",
-			"required": ["url", "sha256"],
+			"description": "The plugin related configuration",
+			"required": ["url"],
 			"properties": {
 				"url": {
 					"type": "string",
-					"description": "The URL of the plugin to use"
+					"description": "The URL of the plugin to use. As a shorthand for github, you can use the following format: gh:{owner}/{repo}@{version} which translates to https://github.com/owner/repo/releases/download/version/plugin.wasm"
 				},
 				"sha256": {
 					"type": "string",
 					"description": "The SHA256 hash of the plugin"
-				},
-				"name": {
-					"type": "string",
-					"description": "The name of the plugin"
-				},
-				"versioned": {
-					"type": "string",
-					"description": "The relative path from the root of the repository to the versioned file"
 				}
 			}
 		}


### PR DESCRIPTION
Closes #4 

Allows shorthand syntax for a Github url: `gh:{owner}/{repo}@{version}` which translates to `https://github.com/owner/repo/releases/download/version/plugin.wasm`